### PR TITLE
secondary-headers

### DIFF
--- a/css/00-banner.css
+++ b/css/00-banner.css
@@ -5,5 +5,5 @@
  Author:         WSU University Communications
  Author URI:     https://web.wsu.edu
  Template:       spine
- Version:        0.1.6
+ Version:        0.1.7
 */

--- a/functions.php
+++ b/functions.php
@@ -13,7 +13,7 @@ add_filter( 'spine_child_theme_version', 'wsu_press_theme_version' );
  * @since 0.1.0
  */
 function wsu_press_theme_version() {
-	return '0.1.6';
+	return '0.1.7';
 }
 
 add_action( 'after_setup_theme', 'WSU_Press_Extended_WooCommerce' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsupress.wsu.edu",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsupress.wsu.edu"

--- a/parts/headers.php
+++ b/parts/headers.php
@@ -26,8 +26,9 @@ $spine_main_header_values = spine_get_main_header();
 		</ul>
 	</div>
 
-<?php if( is_front_page() ) { ?>
-    <div id="press-header">
+	<div id="press-header">
+
+		<?php if ( is_front_page() ) { ?>
 
 		<div id="press-logo">
 			<img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/wsu-press-lg.png' ); ?>"
@@ -36,6 +37,14 @@ $spine_main_header_values = spine_get_main_header();
 
 		<div id="press-slogan"><?php echo esc_html( $spine_main_header_values['site_tagline'] ); ?></div>
 
+		<?php } else { ?>
+
+		<div id="press-site-name"><?php echo esc_html( $spine_main_header_values['site_name'] ); ?></div>
+
+		<div id="press-page-name"><?php the_title(); ?></div>
+
+		<?php } ?>
+
 	</div>
-<?php } ?>
+
 </header>

--- a/parts/headers.php
+++ b/parts/headers.php
@@ -26,7 +26,8 @@ $spine_main_header_values = spine_get_main_header();
 		</ul>
 	</div>
 
-	<div id="press-header">
+<?php if( is_front_page() ) { ?>
+    <div id="press-header">
 
 		<div id="press-logo">
 			<img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/wsu-press-lg.png' ); ?>"
@@ -36,4 +37,5 @@ $spine_main_header_values = spine_get_main_header();
 		<div id="press-slogan"><?php echo esc_html( $spine_main_header_values['site_tagline'] ); ?></div>
 
 	</div>
+<?php } ?>
 </header>

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:         WSU University Communications
  Author URI:     https://web.wsu.edu
  Template:       spine
- Version:        0.1.6
+ Version:        0.1.7
 */
 
 .wsu-press-slideshow {


### PR DESCRIPTION
Remove press logo from secondary page headers. It will show up on
front_page only.